### PR TITLE
Make traitor dev mode gizmo visible only with god mode

### DIFF
--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/HediffComps/HediffComp_Traitor.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/HediffComps/HediffComp_Traitor.cs
@@ -128,7 +128,7 @@ namespace VanillaQuestsExpandedTheGenerator
 
         public override IEnumerable<Gizmo> CompGetGizmos()
         {
-            if (Prefs.DevMode)
+            if (DebugSettings.ShowDevGizmos)
             {
                 yield return new Command_Action
                 {


### PR DESCRIPTION
I've replaced the call to `Prefs.DevMode` with `DebugSettings.ShowDevGizmos`, matching the other dev mode gizmos in the mod. Likely a small oversight.