### PR TITLE
Disable the ability to downgrade the generator during a meltdown

### DIFF
--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Windows and Dialogs/Window_Downgrade.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Windows and Dialogs/Window_Downgrade.cs
@@ -56,9 +56,16 @@ namespace VanillaQuestsExpandedTheGenerator
             }
             if (Widgets.ButtonText(new Rect(inRect.x + num + 10f, inRect.yMax - 30f, num, 30f), "OK".Translate()))
             {
-                Close();
-                Thing thingToMake = GenSpawn.Spawn(ThingMaker.MakeThing(newBuilding), building.PositionHeld, building.Map);
-                thingToMake.SetFaction(building.Faction);
+                if (building is Building_GenetronOverdrive genetronOverdrive && genetronOverdrive.inMeltdown)
+                {
+                    Messages.Message("VQE_DowngradeGenetronMeltdown".Translate(), building, MessageTypeDefOf.RejectInput, false);
+                }
+                else
+                {
+                    Close();
+                    Thing thingToMake = GenSpawn.Spawn(ThingMaker.MakeThing(newBuilding), building.PositionHeld, building.Map);
+                    thingToMake.SetFaction(building.Faction);
+                }
             }
         }
     }

--- a/Languages/English/Keyed/Misc_Gameplay.xml
+++ b/Languages/English/Keyed/Misc_Gameplay.xml
@@ -79,6 +79,7 @@
 	<VQE_DowngradeGenetron>Downgrade to {0}</VQE_DowngradeGenetron>
 	<VQE_DowngradeGenetronDesc>Downgrade the ARC to an earlier stage of construction.</VQE_DowngradeGenetronDesc>
 	<VQE_DowngradeGenetronDialog>Warning, this will downgrade the ARC to {0}. All materials used to upgrade it to the current stage will be lost. Are you sure you want to proceed?</VQE_DowngradeGenetronDialog>
+	<VQE_DowngradeGenetronMeltdown>It's not possible to downgrade the ARC during a meltdown.</VQE_DowngradeGenetronMeltdown>
 	
 	<!-- Reactor abilities -->
 	<VQE_GenetronOverdrive>ARC overdrive</VQE_GenetronOverdrive>


### PR DESCRIPTION
Currently, it's possible to downgrade the generator during a meltdown, preventing the meltdown entirely. I'm assuming this was not intended as this feels like a "cheesy" to avoid it.

The downgrade dialog checks if the generator is during a meltdown, and if it is - display a message that it's disallowed. If the generator is not in a meltdown the downgrade will happen normally.

I've considered adding this check to downgrade gizmo instead, however I've realized that it would still be possible to downgrade a generator having a meltdown if the dialog was opened before a meltdown happened.