### PR TITLE
Upgrade gizmo checks for frame before placing blueprint

### DIFF
--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Basic/Building_Genetron_Basic.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Basic/Building_Genetron_Basic.cs
@@ -30,10 +30,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if(Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_WoodFired.blueprintDef) == null) {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_WoodFired, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
-                    
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_WoodFired);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelBoosted.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelBoosted.cs
@@ -31,10 +31,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_ChemfuelCharged.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_ChemfuelCharged, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_ChemfuelCharged);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelCharged.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelCharged.cs
@@ -31,10 +31,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_ChemfuelFortified.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_ChemfuelFortified, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_ChemfuelFortified);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelFortified.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelFortified.cs
@@ -50,10 +50,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_Geothermal.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_Geothermal, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_Geothermal);
                 };
             }
 
@@ -92,7 +89,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action2.hotKey = KeyBindingDefOf.Misc2;
                 command_Action2.action = delegate
                 {
-                    GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_UraniumPowered, Position, Map, Rotation, Faction.OfPlayer, null);
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_UraniumPowered);
                 };
             }
 

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelPowered.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Chemfuel/Building_Genetron_ChemfuelPowered.cs
@@ -30,11 +30,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_ChemfuelBoosted.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_ChemfuelBoosted, Position, Map, Rotation, Faction.OfPlayer, null);
-
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_ChemfuelBoosted);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Geothermal/Building_Genetron_Geothermal.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Geothermal/Building_Genetron_Geothermal.cs
@@ -30,11 +30,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_SteamPowered.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_SteamPowered, Position, Map, Rotation, Faction.OfPlayer, null);
-
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_SteamPowered);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Geothermal/Building_Genetron_SteamPowered.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Geothermal/Building_Genetron_SteamPowered.cs
@@ -31,10 +31,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_ThermalVent.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_ThermalVent, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_ThermalVent);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Geothermal/Building_Genetron_ThermalVent.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Geothermal/Building_Genetron_ThermalVent.cs
@@ -30,11 +30,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_HeatPowered.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_HeatPowered, Position, Map, Rotation, Faction.OfPlayer, null);
-
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_HeatPowered);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Nuclear/Building_Genetron_Isotopic.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Nuclear/Building_Genetron_Isotopic.cs
@@ -31,11 +31,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_Atomic.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_Atomic, Position, Map, Rotation, Faction.OfPlayer, null);
-
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_Atomic);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Nuclear/Building_Genetron_Nuclear.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Nuclear/Building_Genetron_Nuclear.cs
@@ -32,10 +32,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_Isotopic.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_Isotopic, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_Isotopic);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Nuclear/Building_Genetron_UraniumPowered.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Nuclear/Building_Genetron_UraniumPowered.cs
@@ -30,11 +30,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_Nuclear.blueprintDef) == null)
-                    {
-
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_Nuclear, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_Nuclear);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodBlasting.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodBlasting.cs
@@ -40,10 +40,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_ChemfuelPowered.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_ChemfuelPowered, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_ChemfuelPowered);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodFired.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodFired.cs
@@ -30,10 +30,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_WoodFueled.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_WoodFueled, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_WoodFueled);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodFueled.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodFueled.cs
@@ -30,10 +30,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_WoodPowered.blueprintDef) == null)
-                    {
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_WoodPowered, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_WoodPowered);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodPowered.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Building/Wood/Building_Genetron_WoodPowered.cs
@@ -31,11 +31,7 @@ namespace VanillaQuestsExpandedTheGenerator
                 command_Action.hotKey = KeyBindingDefOf.Misc1;
                 command_Action.action = delegate
                 {
-                    if (Map.thingGrid.ThingAt(Position, InternalDefOf.VQE_Genetron_WoodBlasting.blueprintDef) == null)
-                    {
-
-                        GenConstruct.PlaceBlueprintForBuild(InternalDefOf.VQE_Genetron_WoodBlasting, Position, Map, Rotation, Faction.OfPlayer, null);
-                    }
+                    Utils.PlaceDistinctBlueprint(this, InternalDefOf.VQE_Genetron_WoodBlasting);
                 };
             }
             else

--- a/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Utils/Utils.cs
+++ b/1.5/Source/VanillaQuestsExpanded-TheGenerator/VanillaQuestsExpanded-TheGenerator/Utils/Utils.cs
@@ -117,5 +117,14 @@ namespace VanillaQuestsExpandedTheGenerator
             }
             return false;
         }
+
+        public static void PlaceDistinctBlueprint(Building current, ThingDef replacement)
+        {
+            if (current.Map.thingGrid.ThingAt(current.Position, replacement.blueprintDef) == null &&
+                current.Map.thingGrid.ThingAt(current.Position, replacement.frameDef) == null)
+            {
+                GenConstruct.PlaceBlueprintForBuild(replacement, current.Position, current.Map, current.Rotation, Faction.OfPlayer, null);
+            }
+        }
     }
 }


### PR DESCRIPTION
The current gizmo only checks if a blueprint is present at the same location, but not the building frame. I've changed it so both are checked. On top of that, the upgrade from chemfuel fortified to uranium powered did not have a check for the blueprint, likely due to small oversight.

To avoid copy-pasting the same snippet of the code everywhere, I've made a new method that handles placing the blueprint (`Utils.PlaceDistinctBlueprint`). This should hopefully prove useful if some changes or improvements are ever needed to this code since all the upgrade gizmo actions will be handled in a single place now.

As a slight side note - I could optimize the method placing the blueprint to only use 1 loop rather than 2 (the `ThingAt` call). However, given that this is a method that will rarely be called, and only from gizmos - I've decided that there's likely no point in doing it.